### PR TITLE
Enable `VK_KHR_image_format_list` during device init

### DIFF
--- a/app/src/main/cpp/skyline/gpu/trait_manager.cpp
+++ b/app/src/main/cpp/skyline/gpu/trait_manager.cpp
@@ -46,7 +46,8 @@ namespace skyline::gpu {
                 EXT_SET("VK_EXT_provoking_vertex", hasProvokingVertexExt);
                 EXT_SET("VK_EXT_vertex_attribute_divisor", hasVertexAttributeDivisorExt);
                 EXT_SET_COND("VK_KHR_push_descriptor", supportsPushDescriptors, !quirks.brokenPushDescriptors);
-                EXT_SET("VK_KHR_imageless_framebuffer", hasImagelessFramebuffersExt);
+                EXT_SET("VK_KHR_image_format_list", supportsImageFormatList);
+                EXT_SET_COND("VK_KHR_imageless_framebuffer", hasImagelessFramebuffersExt, supportsImageFormatList);
                 EXT_SET("VK_EXT_global_priority", supportsGlobalPriority);
                 EXT_SET("VK_EXT_shader_viewport_index_layer", supportsShaderViewportIndexLayer);
                 EXT_SET("VK_KHR_spirv_1_4", supportsSpirv14);
@@ -61,6 +62,7 @@ namespace skyline::gpu {
                 EXT_SET("VK_EXT_robustness2", hasRobustness2Ext);
             }
 
+            #undef EXT_SET_COND
             #undef EXT_SET
             #undef EXT_SET_V
         }
@@ -84,7 +86,6 @@ namespace skyline::gpu {
             FEAT_SET(vk::PhysicalDeviceIndexTypeUint8FeaturesEXT, indexTypeUint8, supportsUint8Indices)
         else
             enabledFeatures2.unlink<vk::PhysicalDeviceIndexTypeUint8FeaturesEXT>();
-
 
         if (hasExtendedDynamicStateExt)
             FEAT_SET(vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT, extendedDynamicState, supportsExtendedDynamicState)
@@ -156,9 +157,9 @@ namespace skyline::gpu {
         }
 
         if (hasImagelessFramebuffersExt) {
-            FEAT_SET(vk::PhysicalDeviceImagelessFramebufferFeatures, imagelessFramebuffer, supportsImagelessFramebuffers)
+            FEAT_SET(vk::PhysicalDeviceImagelessFramebufferFeaturesKHR, imagelessFramebuffer, supportsImagelessFramebuffers)
         } else {
-            enabledFeatures2.unlink<vk::PhysicalDeviceImagelessFramebufferFeatures>();
+            enabledFeatures2.unlink<vk::PhysicalDeviceImagelessFramebufferFeaturesKHR>();
         }
 
         if (hasTransformFeedbackExt) {

--- a/app/src/main/cpp/skyline/gpu/trait_manager.h
+++ b/app/src/main/cpp/skyline/gpu/trait_manager.h
@@ -22,6 +22,7 @@ namespace skyline::gpu {
         bool supportsVertexAttributeDivisor{}; //!< If the device supports a divisor for instance-rate vertex attributes (with VK_EXT_vertex_attribute_divisor)
         bool supportsVertexAttributeZeroDivisor{}; //!< If the device supports a zero divisor for instance-rate vertex attributes (with VK_EXT_vertex_attribute_divisor)
         bool supportsPushDescriptors{}; //!< If the device supports push descriptors (with VK_KHR_push_descriptor)
+        bool supportsImageFormatList{}; //!< If the device supports providing a list of formats that can be used with an image (with VK_KHR_image_format_list)
         bool supportsImagelessFramebuffers{}; //!< If the device supports imageless framebuffers (with VK_KHR_imageless_framebuffer)
         bool supportsGlobalPriority{}; //!< If the device supports global priorities for queues (with VK_EXT_global_priority)
         bool supportsMultipleViewports{}; //!< If the device supports more than one viewport
@@ -105,7 +106,7 @@ namespace skyline::gpu {
             vk::PhysicalDeviceExtendedDynamicStateFeaturesEXT,
             vk::PhysicalDeviceRobustness2FeaturesEXT>;
 
-        TraitManager(const DeviceFeatures2 &deviceFeatures2, DeviceFeatures2 &enabledFeatures2, const std::vector<vk::ExtensionProperties> &deviceExtensions, std::vector<std::array<char, VK_MAX_EXTENSION_NAME_SIZE>> &enabledExtensions, const DeviceProperties2 &deviceProperties2, const vk::raii::PhysicalDevice& physicalDevice);
+        TraitManager(const DeviceFeatures2 &deviceFeatures2, DeviceFeatures2 &enabledFeatures2, const std::vector<vk::ExtensionProperties> &deviceExtensions, std::vector<std::array<char, VK_MAX_EXTENSION_NAME_SIZE>> &enabledExtensions, const DeviceProperties2 &deviceProperties2, const vk::raii::PhysicalDevice &physicalDevice);
 
         /**
          * @brief Applies driver specific binary patches to the driver (e.g. BCeNabler)


### PR DESCRIPTION
`VK_KHR_image_format_list` is a requirement for `VK_KHR_imageless_framebuffer`, which we use.